### PR TITLE
Use current branch rather than master for CI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ RUN python3 -m pip install --upgrade pip pytest-cov hypothesis nbval \
       matplotlib pyvtk git+git://github.com/joommf/joommfutil.git
 
 WORKDIR /usr/local
-RUN git clone https://github.com/joommf/discretisedfield.git
+COPY . /usr/local/discretisedfield/
 WORKDIR /usr/local/discretisedfield
 RUN python3 -m pip install .
-


### PR DESCRIPTION
By copying the files that github has given to Travis into the
container, we can run tests on those files. If this is a pull request,
then the files will be those of the pull request.