### PR TITLE
set WORKDIR after installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,6 @@ RUN python3 -m pip install --upgrade pip pytest-cov hypothesis nbval \
 
 WORKDIR /usr/local
 COPY . /usr/local/discretisedfield/
+
+RUN python3 -m pip install /usr/local/discretisedfield
 WORKDIR /usr/local/discretisedfield
-RUN python3 -m pip install .


### PR DESCRIPTION
For some reason, running 'make travis-build' fails on Hans Laptop with the previous version.

The symptom is that the nbval tests fail, and the error is that
'discretisedfield' cannot be imported. The problem disappears if we change

WORKDIR /usr/local/discretisedfield
RUN python3 -m pip install /usr/local/discretisedfield

to

RUN python3 -m pip install /usr/local/discretisedfield
WORKDIR /usr/local/discretisedfield

in the Dockerfile.

I don't understand why; on Travis CI both scenarios work.

For reference, the docker version on Hans' laptop (OSX 10.12.6)

$> docker version
docker version
Client:
 Version:      17.09.0-ce
 API version:  1.32
 Go version:   go1.8.3
 Git commit:   afdb6d4
 Built:        Tue Sep 26 22:40:09 2017
 OS/Arch:      darwin/amd64

Server:
 Version:      17.09.0-ce
 API version:  1.32 (minimum version 1.12)
 Go version:   go1.8.3
 Git commit:   afdb6d4
 Built:        Tue Sep 26 22:45:38 2017
 OS/Arch:      linux/amd64
 Experimental: true